### PR TITLE
Added ``apt_preferences__preset_list`` for advanced users.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,8 @@ v0.1.4
   ``apt_preferences_[^_]`` variables are hereby deprecated but are currently
   still supported to allow a soft migration. [ypid]
 
+- Added ``apt_preferences__preset_list`` for advanced users. [ypid]
+
 v0.1.3
 ------
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,6 +4,12 @@
 
 # .. contents:: Sections
 #    :local:
+#
+# .. APT preferences lists (((
+#
+# -------------------------
+#   APT preferences lists
+# -------------------------
 
 # .. envvar:: apt_preferences__list
 #
@@ -38,20 +44,117 @@ apt_preferences__host_list: []
 # role dependency in :file:`role/meta/main.yml` or in a playbook.
 apt_preferences__dependent_list: []
 
+# .. )))
+
+# .. APT preferences presets (((
+#
+# ---------------------------
+#   APT preferences presets
+# ---------------------------
+#
+# This section contains presets of APT preferences intended for advanced users
+# who want to install software from different releases but want to keep there
+# main system on the stable release.
+#
+# When enabling these presets, you will need to set explicit preferences for
+# packages you want to install from different releases.
+# Examples for such explicit preferences can be found in the
+# `defaults file of the ypid.packages`_ (search for "Package origin presets for
+# Debian GNU/Linux").
+#
+# .. Debian backports have a priority of 100 by default so you will automatically
+#    not upgrade to packages from them.
+#
+
+
+# .. envvar:: apt_preferences__debian_stable_default_preset_list
+#
+# Preset for the stable release of Debian GNU/Linux.
+#
+# Configuring this in APT is needed because releases (stable, testing,
+# unstable) have by default the same priority 500 so when including different
+# releases, APT would just select the newest version (usually unstable). To
+# avoid this, APT preferences are used to change the preferences to prefer
+# stable over testing over unstable.
+apt_preferences__debian_stable_default_preset_list:
+  - package: '*'
+    by_role: 'debops.apt_preferences'
+    suffix: '_Debian'
+    raw: |
+      Explanation: Configure the installed release higher explicitly to the default priority of 500 so that release packages are preferred.
+      Package: *
+      Pin: release o=Debian,n={{ ansible_distribution_release }}
+      Pin-Priority: 500
+
+      Explanation: Configure the installed release higher explicitly to the default priority of 500 so that release packages are preferred.
+      Package: *
+      Pin: release o=Qubes Debian,n={{ ansible_distribution_release }}
+      Pin-Priority: 500
+
+      Explanation: The default priority of packages from backports is 100 which is even lower then testing and unstable (500).
+      Explanation: Prefer backports over testing and unstable but don’t automatically upgrade to them.
+      Package: *
+      Pin: release o=Debian Backports,n={{ ansible_distribution_release }}-backports
+      Pin-Priority: 400
+
+      Explanation: Install packages from testing if no package with the same name is available in release archives or backports or other archives.
+      Package: *
+      Pin: release o=Debian,a=testing
+      Pin-Priority: 50
+
+      Explanation: Only install packages from unstable if explicitly asked for or the package is pined.
+      Package: *
+      Pin: release o=Debian,a=unstable
+      Pin-Priority: -1
+
+      Explanation: Only install packages from experimental if explicitly asked for or the package is pined.
+      Package: *
+      Pin: release o=Debian,a=experimental
+      Pin-Priority: -1
+
+
+# .. envvar:: apt_preferences__preset_list
+#
+# Appropriate preset for your distribution, when one is available.
+# To use it, add the following::
+#
+#    apt_preferences__list:
+#      - '{{ apt_preferences__preset_list | list }}'
+#
+# to your inventory.
+#
+apt_preferences__preset_list: '{{
+    ( (apt_preferences__debian_stable_default_preset_list | list) if (ansible_distribution == "Debian") else [])
+  }}'
+
+# .. )))
+
+# .. Role pin defaults (((
+#
+# ---------------------
+#   Role pin defaults
+# ---------------------
 
 # .. envvar:: apt_preferences__priority_default
 #
 # Default pin priority used, if custom priority is not specified in a pin
 # definition.
-apt_preferences__priority_default: '500'
+apt_preferences__priority_default: 500
 
 
 # .. envvar:: apt_preferences__priority_version
 #
 # Default pin priority used if custom priority is not specified in a versioned
 # pin definition.
-apt_preferences__priority_version: '1001'
+apt_preferences__priority_version: 1001
 
+# .. )))
+
+# .. Role internals (((
+#
+# ------------------
+#   Role internals
+# ------------------
 
 # .. envvar:: apt_preferences__next_release
 #
@@ -73,3 +176,6 @@ apt_preferences__next_release:
   'saucy':    'trusty'
   'trusty':   'utopic'
 
+# .. )))
+
+# .. _`defaults file of the ypid.packages`: https://github.com/ypid/ansible-packages/blob/master/defaults/main.yml


### PR DESCRIPTION
The presets are intended for advanced users who want to install software
from different releases but want to keep there main system on the stable
release.

@drybjed and me discoursed a bit how to add such examples to the role.
The previous consent was to add it to the documentation but I think
adding it to the defaults has some benefits in this case which are that
users can directly use the presets and benefit from updates directly.
Also, this avoids creating redundancy.

The preferences are tested by me for some time now.

Related to
https://github.com/ypid/ansible-packages/commit/cf59393274cf402a6e767c9eb8fc19888b0ba838.