### PR TITLE
Debian suites need to be matched as Archive or Suite and not codename

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -94,7 +94,7 @@ apt_preferences__debian_stable_default_preset_list:
 
       Explanation: In case ansible_distribution_release is not (anymore) the current stable release don’t automatically upgrade to it.
       Package: *
-      Pin: release o=Debian,n=stable
+      Pin: release o=Debian,a=stable
       Pin-Priority: 100
 
       Explanation: Install packages from testing if no package with the same name is available in release archives or backports or other archives.


### PR DESCRIPTION
Fixes: #23 

Not sure how that went through my tests. There was definitely something wired even with #23. Seems I found it :)